### PR TITLE
Optionally allow modid's recipes to be staged using the item

### DIFF
--- a/src/main/java/uk/artdude/zenstages/stager/Stage.java
+++ b/src/main/java/uk/artdude/zenstages/stager/Stage.java
@@ -155,21 +155,21 @@ public class Stage {
 
     @ZenMethod
     @SuppressWarnings("UnusedReturnValue")
-    public Stage addModId(String modId) {
+    public Stage addModId(String modId, @Optional(valueBoolean = false) boolean stageRecipeWithItem) {
         if (!Loader.isModLoaded(modId)) {
             CraftTweakerAPI.logError(String.format("[Stage %s] Failed to add `%s` as the mod is not even loaded?", getStage(), modId));
 
             return this;
         }
-        this.stagedEntries.add(new TypeMod(modId));
+        this.stagedEntries.add(new TypeMod(modId, stageRecipeWithItem));
 
         return this;
     }
 
     @ZenMethod
-    public Stage addModId(String[] modIds) {
+    public Stage addModId(String[] modIds, @Optional(valueBoolean = false) boolean stageRecipeWithItem) {
         for (String modId : modIds) {
-            addModId(modId);
+            addModId(modId, stageRecipeWithItem);
         }
 
         return this;

--- a/src/main/java/uk/artdude/zenstages/stager/Stage.java
+++ b/src/main/java/uk/artdude/zenstages/stager/Stage.java
@@ -155,21 +155,21 @@ public class Stage {
 
     @ZenMethod
     @SuppressWarnings("UnusedReturnValue")
-    public Stage addModId(String modId, @Optional(valueBoolean = false) boolean stageRecipeWithItem) {
+    public Stage addModId(String modId, @Optional(valueBoolean = false) boolean stageRecipesWithItems) {
         if (!Loader.isModLoaded(modId)) {
             CraftTweakerAPI.logError(String.format("[Stage %s] Failed to add `%s` as the mod is not even loaded?", getStage(), modId));
 
             return this;
         }
-        this.stagedEntries.add(new TypeMod(modId, stageRecipeWithItem));
+        this.stagedEntries.add(new TypeMod(modId, stageRecipesWithItems));
 
         return this;
     }
 
     @ZenMethod
-    public Stage addModId(String[] modIds, @Optional(valueBoolean = false) boolean stageRecipeWithItem) {
+    public Stage addModId(String[] modIds, @Optional(valueBoolean = false) boolean stageRecipesWithItems) {
         for (String modId : modIds) {
-            addModId(modId, stageRecipeWithItem);
+            addModId(modId, stageRecipesWithItems);
         }
 
         return this;

--- a/src/main/java/uk/artdude/zenstages/stager/type/TypeMod.java
+++ b/src/main/java/uk/artdude/zenstages/stager/type/TypeMod.java
@@ -20,6 +20,20 @@ public class TypeMod extends TypeBase<String> {
         this.stageRecipesWithItems = stageRecipesWithItems;
     }
 
+    /**
+     * Both true and false for stageRecipesWithItems will result in recipes AND items being staged for the mod ID.
+     * When `stageRecipesWithItems == true`, to keep all the logic within a single loop, Item Staging is done
+     * individually rather than using `ItemStagesCrT.stageModItems(stageName, getValue())`
+     *
+     * When `Recipes.setRecipeStageByMod()` is called (when stageRecipesWithItems == false),
+     * RecipeStages searches the recipes registry for all recipes under the mod specified.
+     *
+     * Alternatively, with `stageRecipesWithItems == true`, the output item is passed to `Recipes.setRecipeStage`
+     * which results in RecipeStages searching for all recipes that output that item.
+     * This causes OTHER MOD's recipes for that item to ALSO get staged.
+     * This is ideal when modifying an item's recipes using CraftTweaker for example
+     * This behaviour is exactly the same as when calling ZenStages' addIngredient method.
+     */
     @Override
     public void build(String stageName) {
         if (!stageRecipesWithItems) {

--- a/src/main/java/uk/artdude/zenstages/stager/type/TypeMod.java
+++ b/src/main/java/uk/artdude/zenstages/stager/type/TypeMod.java
@@ -1,18 +1,42 @@
 package uk.artdude.zenstages.stager.type;
 
 import com.blamejared.recipestages.handlers.Recipes;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.mc1120.item.MCItemStack;
+import net.darkhax.bookshelf.util.ModUtils;
+import net.darkhax.itemstages.compat.crt.ActionAddItemRestriction;
 import net.darkhax.itemstages.compat.crt.ItemStagesCrT;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 public class TypeMod extends TypeBase<String> {
+    private boolean stageRecipeWithItem;
 
-    public TypeMod(String modId) {
+    public TypeMod(String modId, boolean stageRecipeWithItem) {
         super(modId);
+
+        this.stageRecipeWithItem = stageRecipeWithItem;
     }
 
     @Override
     public void build(String stageName) {
-        ItemStagesCrT.stageModItems(stageName, getValue());
-        Recipes.setRecipeStageByMod(stageName, getValue());
+        if (!stageRecipeWithItem) {
+            ItemStagesCrT.stageModItems(stageName, getValue());
+            Recipes.setRecipeStageByMod(stageName, getValue());
+            return;
+        }
+
+        for (final Item item : ModUtils.getSortedEntries(ForgeRegistries.ITEMS).get(getValue())) {
+            if (item != null && item != Items.AIR) {
+                // Stage Item
+                CraftTweakerAPI.apply(new ActionAddItemRestriction(stageName, item));
+
+                // Stage Item's recipes
+                Recipes.setRecipeStage(stageName, MCItemStack.createNonCopy(new ItemStack(item)));
+            }
+        }
     }
 
     @Override

--- a/src/main/java/uk/artdude/zenstages/stager/type/TypeMod.java
+++ b/src/main/java/uk/artdude/zenstages/stager/type/TypeMod.java
@@ -12,17 +12,17 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 public class TypeMod extends TypeBase<String> {
-    private boolean stageRecipeWithItem;
+    private boolean stageRecipesWithItems;
 
-    public TypeMod(String modId, boolean stageRecipeWithItem) {
+    public TypeMod(String modId, boolean stageRecipesWithItems) {
         super(modId);
 
-        this.stageRecipeWithItem = stageRecipeWithItem;
+        this.stageRecipesWithItems = stageRecipesWithItems;
     }
 
     @Override
     public void build(String stageName) {
-        if (!stageRecipeWithItem) {
+        if (!stageRecipesWithItems) {
             ItemStagesCrT.stageModItems(stageName, getValue());
             Recipes.setRecipeStageByMod(stageName, getValue());
             return;


### PR DESCRIPTION
Setting stageRecipeWithItem to true allows the developer to specify that rather than staging all recipes created by a mod, it stages all recipes an item of that mod has.

This is most beneficial when trying to stage custom recipes for an item in a more simplified way. I made it optional to maintain the current behaviour as well as allowing the option to do either way (as staging the recipes of a mod would require less time).